### PR TITLE
Refactor to stream and lower memory usage for large backups and more...

### DIFF
--- a/ab_decrypt.py
+++ b/ab_decrypt.py
@@ -12,14 +12,14 @@
 
 import sys
 import platform
+import codecs
+import ctypes
 import zlib
 from binascii import unhexlify, hexlify
 from Crypto.Protocol.KDF import PBKDF2
 from Crypto.Cipher import AES
 from optparse import OptionParser
-import codecs
 from struct import pack
-import ctypes
 
 VERBOSITY=0
 CHUNK_SIZE=128*1024

--- a/ab_decrypt.py
+++ b/ab_decrypt.py
@@ -64,33 +64,29 @@ def masterKeyJavaConversion(k):
   # Narrowing Primitive Conversion : https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.3
   toUnsigned16bits = [ ctypes.c_ushort(x).value & 0xffff for x in toSigned ]
   if options.verbose>2:
-    for c in toUnsigned16bits: dprint('%x ' % c,end='')
-    dprint('')
+    dprint(('{:x} '*len(toUnsigned16bits)).format(*toUnsigned16bits))
   """ 
   The Java programming language represents text in sequences of 16-bit code UNITS, using the UTF-16 encoding. 
   https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.1
   """
-  toBytes = [ pack('>H',c) for c in toUnsigned16bits ] #unsigned short to bytes
+  toBytes = pack(f'>{len(toUnsigned16bits)}H', *toUnsigned16bits ) #unsigned short to bytes
   if options.verbose>2:
-    for c in toBytes: dprint(hexlify(c),end=',')
-    dprint('')
+    dprint(hexlify(toBytes, sep=',').decode('ascii'))
   
-  toUtf16be = [ codecs.decode(v,'UTF-16BE') for v in toBytes ] #from bytes to Utf16
+  toUtf16be = codecs.decode(toBytes,'UTF-16BE') #from bytes to Utf16
   if options.verbose>2:
-    for c in toUtf16be: dprint(repr(c),end='+')
-    dprint('')
+    dprint(hexlify(toUtf16be.encode('UTF-16BE'), sep='+').decode('ascii'))
   """ 
    https://developer.android.com/reference/javax/crypto/spec/PBEKeySpec.html
    \"Different PBE mechanisms may consume different bits of each password character. 
    For example, the PBE mechanism defined in PKCS #5 looks at only the low order 8 bits of each character, 
    whereas PKCS #12 looks at all 16 bits of each character. \"  
   """
-  toUft8 = [ codecs.encode(t,'UTF-8') for t in toUtf16be ] # char must be encoded as UTF-8 first
+  toUft8 = codecs.encode(toUtf16be,'UTF-8') # char must be encoded as UTF-8 first
   if options.verbose>2:
-    for c in toUft8: dprint(hexlify(c),end='+')
-    dprint('')
+    dprint(hexlify(toUft8, sep='+').decode('ascii'))
 
-  return bytes( b''.join(toUft8) )
+  return toUft8
 
 def chunkReader(f, chunkSize=CHUNK_SIZE):
   data = f.read(chunkSize)

--- a/ab_decrypt.py
+++ b/ab_decrypt.py
@@ -190,7 +190,7 @@ if header['encryption']==b'AES-256':
   # decryption using master key and iv
   compressedIter = decrypt(chunkReader(f), AES.new(mk, AES.MODE_CBC, iv))
 
-elif header['encryption']=='none':
+elif header['encryption']==b'none':
   dprint('no encryption')
   compressedIter = chunkReader(f)
 else:

--- a/ab_decrypt.py
+++ b/ab_decrypt.py
@@ -112,7 +112,7 @@ def decompress(compressedDataIter, blockSize=CHUNK_SIZE):
 
 parser = OptionParser()
 parser.add_option("-p", "--pw", dest="password", help="password")
-parser.add_option("-o", "--out", dest="output", default="backup.tar", help="output file")
+parser.add_option("-o", "--out", dest="output", default="-", help="output file")
 parser.add_option("-v", "--verbose", type='int', dest="verbose", default=0, help="verbose mode")
 parser.add_option("-b", "--backup", dest="backup", help="input file")
 (options, args) = parser.parse_args()
@@ -194,7 +194,10 @@ else:
 if options.verbose:
   dprint('decompression... ', end='')
 # decompression (zlib stream)
-out = open(options.output,'wb')
+if options.output == '-':
+  out = sys.stdout.buffer
+else:
+  out = open(options.output,'wb')
 dprint('writing backup as .tar ... ', end='', flush=True)
 for decData in decompress(compressedIter):
   out.write(decData)

--- a/ab_decrypt.py
+++ b/ab_decrypt.py
@@ -11,6 +11,7 @@
 #from __future__ import print_function
 
 import sys
+import platform
 from binascii import unhexlify, hexlify
 from Crypto.Protocol.KDF import PBKDF2
 from Crypto.Cipher import AES
@@ -19,6 +20,16 @@ from optparse import OptionParser
 import codecs
 from struct import pack
 import ctypes
+
+def inputtty(prompt=""):
+  if platform.system() == "Windows":
+    return input(prompt)
+  with open('/dev/tty', 'rb') as ftty:
+    if prompt:
+      with open('/dev/tty', 'wb') as fwtty:
+        fwtty.write(prompt.encode('utf8'))
+        fwtty.flush()
+    return ftty.readline().decode('utf8').rstrip("\n")
 
 def masterKeyJavaConversion(k):
   """
@@ -102,7 +113,7 @@ if options.verbose>1:
 
 if header['encryption']==b'AES-256':
   if options.password is None:
-    options.password = input("Enter Password: ")
+    options.password = inputtty("Enter Password: ")
   password = options.password.encode('utf-8')
   #get PBKDF2 parameters to decrypt master key blob
   header['upSalt'] = unhexlify( f.readline()[:-1] )

--- a/ab_decrypt.py
+++ b/ab_decrypt.py
@@ -102,8 +102,7 @@ if options.verbose>1:
 
 if header['encryption']==b'AES-256':
   if options.password is None:
-    print('-p argument is mandatory')
-    exit()
+    options.password = input("Enter Password: ")
   password = options.password.encode('utf-8')
   #get PBKDF2 parameters to decrypt master key blob
   header['upSalt'] = unhexlify( f.readline()[:-1] )

--- a/ab_decrypt.py
+++ b/ab_decrypt.py
@@ -169,7 +169,7 @@ def decompress(compressedDataIter, blockSize=CHUNK_SIZE):
 def ab2tar(f, options):
   if f.readline()[:-1]!=b'ANDROID BACKUP':
     dprint('not ANDROID BACKUP')
-    exit(1)
+    return False
 
   #parse header
   header = readHeader(f)
@@ -186,7 +186,7 @@ def ab2tar(f, options):
     compressedIter = chunkReader(f)
   else:
     dprint('unknown encryption')
-    exit(1)
+    return False
 
   # decompression (zlib stream)
   if options.output == '-':
@@ -198,6 +198,7 @@ def ab2tar(f, options):
     out.write(decData)
   dprint(f'OK. Filename is \'{options.output}\', {out.tell()} bytes written.')
   out.close()
+  return True
 
 def main(argv):
   global VERBOSITY
@@ -211,10 +212,10 @@ def main(argv):
   VERBOSITY = options.verbose
   if options.backup is None:
     dprint('-b argument is mandatory')
-    exit(1)
+    return 1
 
   with open(options.backup,'rb') as abfile:
-    ab2tar(abfile, options)
+    return int(not ab2tar(abfile, options))
 
 if __name__ == "__main__":
-  main(sys.argv[1:])
+  exit(main(sys.argv[1:]))

--- a/ab_decrypt.py
+++ b/ab_decrypt.py
@@ -115,13 +115,13 @@ parser.add_option("-b", "--backup", dest="backup", help="input file")
 
 if options.backup is None:
   dprint('-b argument is mandatory')
-  exit()
+  exit(1)
   
 f=open(options.backup,'rb')
 
 if f.readline()[:-1]!=b'ANDROID BACKUP':
   dprint('not ANDROID BACKUP')
-  exit()
+  exit(1)
   
 #parse header   
 header = dict()  
@@ -185,8 +185,8 @@ elif header['encryption']=='none':
   compressedIter = chunkReader(f)
 else:
   dprint('unknown encryption')
-  exit()
-  
+  exit(1)
+
 if options.verbose:
   dprint('decompression... ', end='')
 # decompression (zlib stream)


### PR DESCRIPTION
This PR does a bunch of things

- There's a lot of refactoring to make it easily importable as a module
- Add streaming capability so that the whole decompressed backup doesn't have to fit in memory (great for when you have backups of several GBs)
- Fix a bug where unencrypted backups were not being handled
- Print all output to stderr so that the tar file can be written to stdout
- Prompt for password if not is given and one is needed (this is good so that passwords do not show up in `ps`

Thanks for doing the harder work of figuring out the right dance to get the master key and do the decryption!
